### PR TITLE
Add persistent inventory singleton

### DIFF
--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -1,0 +1,35 @@
+using System;
+using UnityEngine;
+
+public class Inventory : MonoBehaviour
+{
+    public static Inventory Instance { get; private set; }
+
+    public int woodCount;
+
+    public event Action<int> OnWoodChanged;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void AddWood(int amount)
+    {
+        woodCount += amount;
+        OnWoodChanged?.Invoke(woodCount);
+    }
+
+    public void RemoveWood(int amount)
+    {
+        woodCount = Mathf.Max(0, woodCount - amount);
+        OnWoodChanged?.Invoke(woodCount);
+    }
+}

--- a/Assets/Scripts/Inventory.cs.meta
+++ b/Assets/Scripts/Inventory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 599782b806e84d7ab06e5a75afb4e6b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add Inventory singleton to track wood across scenes
- fire OnWoodChanged event on wood count updates

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68acccf76be0832e9098855090254ded