### PR TITLE
Add basic quest system with board and manager

### DIFF
--- a/Assets/Scripts/Quest.meta
+++ b/Assets/Scripts/Quest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94c85149e227443291c8756a7b2ab68a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Quest/QuestBoard.cs
+++ b/Assets/Scripts/Quest/QuestBoard.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Interaction;
+
+/// <summary>
+/// Interactable quest board that hands out quests to the player.
+/// Quests cycle through a predefined list each time the board is used.
+/// </summary>
+public class QuestBoard : Interactable
+{
+    [SerializeField]
+    [Tooltip("Queue of quests offered by this board.")]
+    private List<QuestSO> questQueue = new List<QuestSO>();
+
+    private int currentIndex;
+
+    private void Start()
+    {
+        // Provide a default cycle of quests if none were assigned via the inspector.
+        if (questQueue.Count == 0)
+        {
+            questQueue.Add(CreateQuest(10));
+            questQueue.Add(CreateQuest(15));
+            questQueue.Add(CreateQuest(20));
+        }
+    }
+
+    private QuestSO CreateQuest(int wood)
+    {
+        var quest = ScriptableObject.CreateInstance<QuestSO>();
+        quest.woodRequired = wood;
+        quest.goldReward = 0;
+        return quest;
+    }
+
+    /// <summary>
+    /// Gives the player the next quest if no quest is currently active.
+    /// </summary>
+    public override void Interact()
+    {
+        if (QuestManager.Instance.ActiveQuest != null)
+        {
+            return;
+        }
+
+        var quest = questQueue[currentIndex];
+        currentIndex = (currentIndex + 1) % questQueue.Count;
+        QuestManager.Instance.AssignQuest(quest);
+    }
+}

--- a/Assets/Scripts/Quest/QuestBoard.cs.meta
+++ b/Assets/Scripts/Quest/QuestBoard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b082bd9545db461eac67978e90a65e77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Quest/QuestManager.cs
+++ b/Assets/Scripts/Quest/QuestManager.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Handles the currently active quest and updates a small UI display.
+/// </summary>
+public class QuestManager : MonoBehaviour
+{
+    public static QuestManager Instance { get; private set; }
+
+    /// <summary>Currently active quest. Null if no quest is running.</summary>
+    public QuestSO ActiveQuest { get; private set; }
+
+    public event Action<QuestSO> OnQuestAssigned;
+
+    [SerializeField]
+    [Tooltip("UI text element used to display current quest info.")]
+    private Text questText;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// Assigns a quest as the current active quest and updates the UI.
+    /// </summary>
+    public void AssignQuest(QuestSO quest)
+    {
+        ActiveQuest = quest;
+        OnQuestAssigned?.Invoke(quest);
+        if (questText != null)
+        {
+            questText.text = $"Gather {quest.woodRequired} wood";
+        }
+    }
+
+    /// <summary>
+    /// Clears the active quest and resets the UI display.
+    /// </summary>
+    public void ClearQuest()
+    {
+        ActiveQuest = null;
+        if (questText != null)
+        {
+            questText.text = string.Empty;
+        }
+    }
+}

--- a/Assets/Scripts/Quest/QuestManager.cs.meta
+++ b/Assets/Scripts/Quest/QuestManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5847d41034694efe914c8f52d4339b2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Quest/QuestSO.cs
+++ b/Assets/Scripts/Quest/QuestSO.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// ScriptableObject representing a wood delivery quest.
+/// Stores the amount of wood required and the reward given on completion.
+/// </summary>
+[CreateAssetMenu(menuName = "Quests/Quest")]
+public class QuestSO : ScriptableObject
+{
+    [Tooltip("How much wood the player must deliver to finish the quest.")]
+    public int woodRequired = 10;
+
+    [Tooltip("Gold rewarded for completing the quest.")]
+    public int goldReward = 0;
+}

--- a/Assets/Scripts/Quest/QuestSO.cs.meta
+++ b/Assets/Scripts/Quest/QuestSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f652284b2383405b893455e67eb4c74e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add QuestSO ScriptableObject to define wood quests and rewards
- implement QuestManager singleton to track active quest and update UI
- create QuestBoard interactable that cycles through wood quests and assigns them

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_b_68accd90f1f4832ebc432a0bd8a9803f