### PR TITLE
Add Tree ScriptableObject and respawn behaviour

### DIFF
--- a/Assets/Scripts/Minigame.meta
+++ b/Assets/Scripts/Minigame.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 024e1d1f3efe4d3e97c62d19b405dcca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Minigame/MinigameManager.cs
+++ b/Assets/Scripts/Minigame/MinigameManager.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles launching of minigames.  Currently a placeholder.
+/// </summary>
+public class MinigameManager : MonoBehaviour
+{
+    /// <summary>
+    /// Begin a minigame for the supplied tree.
+    /// </summary>
+    public static void StartGame(Tree tree)
+    {
+        // Minigame logic will be implemented later.
+    }
+}

--- a/Assets/Scripts/Minigame/MinigameManager.cs.meta
+++ b/Assets/Scripts/Minigame/MinigameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58368609f1904ae19d922926ae8efc12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Tree.meta
+++ b/Assets/Scripts/Tree.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfe9af66ed124e7093ed871e3dea053f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Tree/Tree.cs
+++ b/Assets/Scripts/Tree/Tree.cs
@@ -1,0 +1,70 @@
+using System.Collections;
+using UnityEngine;
+using Interaction;
+
+/// <summary>
+/// Represents a tree that the player can interact with.  Tracks remaining
+/// interaction attempts and handles respawn behaviour when depleted.
+/// </summary>
+[RequireComponent(typeof(Collider))]
+public class Tree : Interactable
+{
+    [SerializeField]
+    [Tooltip("Configuration data for this tree.")]
+    private TreeSO data;
+
+    private int remainingAttempts;
+    private Collider treeCollider;
+    private Renderer[] renderers;
+
+    private void Awake()
+    {
+        treeCollider = GetComponent<Collider>();
+        renderers = GetComponentsInChildren<Renderer>();
+        if (data != null)
+        {
+            remainingAttempts = data.attempts;
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Interact()
+    {
+        if (remainingAttempts <= 0)
+        {
+            return;
+        }
+
+        MinigameManager.StartGame(this);
+        remainingAttempts--;
+
+        if (remainingAttempts <= 0)
+        {
+            SetEnabled(false);
+            StartCoroutine(RespawnCoroutine());
+        }
+    }
+
+    private IEnumerator RespawnCoroutine()
+    {
+        var waitTime = data != null ? data.respawnTime : 0f;
+        yield return new WaitForSeconds(waitTime);
+        remainingAttempts = data != null ? data.attempts : 0;
+        SetEnabled(true);
+    }
+
+    private void SetEnabled(bool value)
+    {
+        if (treeCollider != null)
+        {
+            treeCollider.enabled = value;
+        }
+        if (renderers != null)
+        {
+            foreach (var r in renderers)
+            {
+                r.enabled = value;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Tree/Tree.cs.meta
+++ b/Assets/Scripts/Tree/Tree.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e67f073937741198e3232039d7f74cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Tree/TreeSO.cs
+++ b/Assets/Scripts/Tree/TreeSO.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// Configuration data for a tree, including how many attempts the
+/// player has before the tree respawns and the time it takes to respawn.
+/// </summary>
+[CreateAssetMenu(menuName = "Trees/Tree Data")]
+public class TreeSO : ScriptableObject
+{
+    [Tooltip("Number of times the tree can be interacted with before it respawns.")]
+    public int attempts = 3;
+
+    [Tooltip("Time in seconds before the tree respawns.")]
+    public float respawnTime = 5f;
+}

--- a/Assets/Scripts/Tree/TreeSO.cs.meta
+++ b/Assets/Scripts/Tree/TreeSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd44b821b5b84adf9e7ad1a6410a0006
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add TreeSO ScriptableObject for attempts and respawn timing
- implement Tree interaction to launch minigame and handle respawn after attempts run out
- stub MinigameManager with StartGame method

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68acce6ac7f8832eb42747affd7a5f9a