### PR TITLE
Add timing minigame for wood harvesting

### DIFF
--- a/Assets/Resources/MinigameManager.prefab
+++ b/Assets/Resources/MinigameManager.prefab
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: MinigameManager
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+--- !u!224 &2
+RectTransform:
+  m_GameObject: {fileID: 1}
+--- !u!223 &3
+Canvas:
+  m_GameObject: {fileID: 1}
+--- !u!114 &4
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Script: {fileID: 11500000, guid: 58368609f1904ae19d922926ae8efc12, type: 3}
+# UI elements are created by script at runtime

--- a/Assets/Resources/MinigameManager.prefab.meta
+++ b/Assets/Resources/MinigameManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d0db72bc11ff4af39bfb4ec20a25cd24
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Minigame/MinigameManager.cs
+++ b/Assets/Scripts/Minigame/MinigameManager.cs
@@ -1,15 +1,134 @@
+using System.Collections;
 using UnityEngine;
+using UnityEngine.UI;
 
 /// <summary>
-/// Handles launching of minigames.  Currently a placeholder.
+/// Handles the wood chopping timing minigame.
 /// </summary>
 public class MinigameManager : MonoBehaviour
 {
+    private const float GoodWidth = 0.20f;
+    private const float PerfectWidth = 0.06f;
+    private const float BaseSpeed = 1f;
+    private const float SpeedStep = 0.5f;
+
+    [SerializeField] private RectTransform indicator;
+    [SerializeField] private RectTransform goodZone;
+    [SerializeField] private RectTransform perfectZone;
+    [SerializeField] private Text feedbackText;
+
+    private float speed;
+    private bool resolved;
+
     /// <summary>
-    /// Begin a minigame for the supplied tree.
+    /// Launch the minigame.  The bar speed increases with each attempt.
     /// </summary>
-    public static void StartGame(Tree tree)
+    public static void StartGame(int attempt)
     {
-        // Minigame logic will be implemented later.
+        var prefab = Resources.Load<MinigameManager>("MinigameManager");
+        if (prefab != null)
+        {
+            Instantiate(prefab).Initialize(attempt);
+        }
+    }
+
+    private void Initialize(int attempt)
+    {
+        if (indicator == null)
+        {
+            BuildUI();
+        }
+
+        speed = BaseSpeed + (attempt - 1) * SpeedStep;
+
+        goodZone.anchorMin = new Vector2(0.5f - GoodWidth / 2f, 0f);
+        goodZone.anchorMax = new Vector2(0.5f + GoodWidth / 2f, 1f);
+
+        perfectZone.anchorMin = new Vector2(0.5f - PerfectWidth / 2f, 0f);
+        perfectZone.anchorMax = new Vector2(0.5f + PerfectWidth / 2f, 1f);
+    }
+
+    private void BuildUI()
+    {
+        var bar = new GameObject("Bar", typeof(RectTransform), typeof(Image));
+        bar.transform.SetParent(transform, false);
+        var barRect = bar.GetComponent<RectTransform>();
+        barRect.anchorMin = new Vector2(0.1f, 0.45f);
+        barRect.anchorMax = new Vector2(0.9f, 0.55f);
+
+        goodZone = CreateZone("GoodZone", barRect);
+        perfectZone = CreateZone("PerfectZone", barRect);
+
+        indicator = new GameObject("Indicator", typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
+        indicator.SetParent(barRect, false);
+        indicator.anchorMin = new Vector2(0f, 0f);
+        indicator.anchorMax = new Vector2(0f, 1f);
+        indicator.sizeDelta = Vector2.zero;
+
+        feedbackText = new GameObject("Feedback", typeof(RectTransform), typeof(Text)).GetComponent<Text>();
+        feedbackText.transform.SetParent(transform, false);
+        feedbackText.alignment = TextAnchor.MiddleCenter;
+        feedbackText.gameObject.SetActive(false);
+    }
+
+    private RectTransform CreateZone(string name, RectTransform parent)
+    {
+        var zone = new GameObject(name, typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
+        zone.SetParent(parent, false);
+        zone.anchorMin = new Vector2(0.5f, 0f);
+        zone.anchorMax = new Vector2(0.5f, 1f);
+        zone.sizeDelta = Vector2.zero;
+        return zone;
+    }
+
+    private void Update()
+    {
+        if (resolved || indicator == null)
+        {
+            return;
+        }
+
+        float t = Mathf.PingPong(Time.time * speed, 1f);
+        indicator.anchorMin = new Vector2(t, 0f);
+        indicator.anchorMax = new Vector2(t, 1f);
+
+        if (Input.GetKeyDown(KeyCode.Space) || Input.GetKeyDown(KeyCode.E))
+        {
+            Evaluate(t);
+        }
+    }
+
+    private void Evaluate(float pos)
+    {
+        resolved = true;
+
+        int gain = 1;
+        if (pos >= 0.5f - PerfectWidth / 2f && pos <= 0.5f + PerfectWidth / 2f)
+        {
+            gain = 3;
+        }
+        else if (pos >= 0.5f - GoodWidth / 2f && pos <= 0.5f + GoodWidth / 2f)
+        {
+            gain = 2;
+        }
+
+        if (Inventory.Instance != null)
+        {
+            Inventory.Instance.AddWood(gain);
+        }
+
+        if (feedbackText != null)
+        {
+            feedbackText.text = "+" + gain;
+            feedbackText.gameObject.SetActive(true);
+        }
+
+        StartCoroutine(Close());
+    }
+
+    private IEnumerator Close()
+    {
+        yield return new WaitForSeconds(0.5f);
+        Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/Tree/Tree.cs
+++ b/Assets/Scripts/Tree/Tree.cs
@@ -35,7 +35,8 @@ public class Tree : Interactable
             return;
         }
 
-        MinigameManager.StartGame(this);
+        int attemptNumber = (data != null ? data.attempts : 0) - remainingAttempts + 1;
+        MinigameManager.StartGame(attemptNumber);
         remainingAttempts--;
 
         if (remainingAttempts <= 0)


### PR DESCRIPTION
## Summary
- introduce `MinigameManager` prefab and script to run a timing bar minigame with perfect (6%) and good (20%) zones
- bar speed increases per tree attempt and awards 3/2/1 wood via `Inventory.AddWood`
- show gain feedback and close the minigame after each attempt

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_b_68accf68c7d4832eafe6208a0d93b125