### PR TITLE
Add wood HUD counter and quest progress UI

### DIFF
--- a/Assets/Scripts/Quest/QuestManager.cs
+++ b/Assets/Scripts/Quest/QuestManager.cs
@@ -1,6 +1,6 @@
 using System;
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro;
 
 /// <summary>
 /// Handles the currently active quest and updates a small UI display.
@@ -15,8 +15,8 @@ public class QuestManager : MonoBehaviour
     public event Action<QuestSO> OnQuestAssigned;
 
     [SerializeField]
-    [Tooltip("UI text element used to display current quest info.")]
-    private Text questText;
+    [Tooltip("UI text element used to display current quest progress.")]
+    private TMP_Text questText;
 
     private void Awake()
     {
@@ -37,9 +37,10 @@ public class QuestManager : MonoBehaviour
     {
         ActiveQuest = quest;
         OnQuestAssigned?.Invoke(quest);
-        if (questText != null)
+        if (Inventory.Instance != null)
         {
-            questText.text = $"Gather {quest.woodRequired} wood";
+            Inventory.Instance.OnWoodChanged += UpdateQuestProgress;
+            UpdateQuestProgress(Inventory.Instance.woodCount);
         }
     }
 
@@ -49,9 +50,25 @@ public class QuestManager : MonoBehaviour
     public void ClearQuest()
     {
         ActiveQuest = null;
+        if (Inventory.Instance != null)
+        {
+            Inventory.Instance.OnWoodChanged -= UpdateQuestProgress;
+        }
         if (questText != null)
         {
             questText.text = string.Empty;
         }
+    }
+
+    private void UpdateQuestProgress(int currentWood)
+    {
+        if (ActiveQuest == null || questText == null)
+        {
+            return;
+        }
+
+        int required = ActiveQuest.woodRequired;
+        int clamped = Mathf.Min(currentWood, required);
+        questText.text = $"{clamped} / {required} wood";
     }
 }

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5d512a348ca4337b9aed09690113011
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/WoodCounterUI.cs
+++ b/Assets/Scripts/UI/WoodCounterUI.cs
@@ -1,0 +1,39 @@
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// Updates a HUD text element to display the current wood count.
+/// Listens to <see cref="Inventory.OnWoodChanged"/> to remain in sync
+/// with the player's inventory.
+/// </summary>
+public class WoodCounterUI : MonoBehaviour
+{
+    [SerializeField]
+    [Tooltip("Text element used to display the player's wood count.")]
+    private TMP_Text woodText;
+
+    private void OnEnable()
+    {
+        if (Inventory.Instance != null)
+        {
+            Inventory.Instance.OnWoodChanged += HandleWoodChanged;
+            HandleWoodChanged(Inventory.Instance.woodCount);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (Inventory.Instance != null)
+        {
+            Inventory.Instance.OnWoodChanged -= HandleWoodChanged;
+        }
+    }
+
+    private void HandleWoodChanged(int amount)
+    {
+        if (woodText != null)
+        {
+            woodText.text = amount.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/UI/WoodCounterUI.cs.meta
+++ b/Assets/Scripts/UI/WoodCounterUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56f08f2732304561943ba8ac2349243b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Village/Storage.cs
+++ b/Assets/Scripts/Village/Storage.cs
@@ -11,7 +11,31 @@ public class Storage : Interactable
     [SerializeField]
     private VillageProgress villageProgress;
 
+    [SerializeField]
+    [Tooltip("Panel shown when the player interacts, allowing them to deliver wood.")]
+    private GameObject deliverAllPanel;
+
+    private void Start()
+    {
+        if (deliverAllPanel != null)
+        {
+            deliverAllPanel.SetActive(false);
+        }
+    }
+
     public override void Interact()
+    {
+        if (deliverAllPanel != null)
+        {
+            deliverAllPanel.SetActive(true);
+        }
+    }
+
+    /// <summary>
+    /// Delivers the required amount of wood for the active quest and advances the village.
+    /// Intended to be called by the Deliver All button.
+    /// </summary>
+    public void DeliverAll()
     {
         var quest = QuestManager.Instance.ActiveQuest;
         if (quest == null)
@@ -23,6 +47,11 @@ public class Storage : Interactable
         {
             Inventory.Instance.RemoveWood(quest.woodRequired);
             villageProgress.AdvancePhase();
+        }
+
+        if (deliverAllPanel != null)
+        {
+            deliverAllPanel.SetActive(false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- show current wood count on HUD that updates with inventory
- track quest progress using `X / N wood` display that reacts to wood changes
- open deliver-all panel when interacting with storage and handle deliveries

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68acd1b87fa4832e8fc7e0255e04bebd