### PR TITLE
Add audio manager and particle effects for gameplay feedback

### DIFF
--- a/Assets/Scripts/Audio.meta
+++ b/Assets/Scripts/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27f9ba1e4e364b9195273e1315e5ff57
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Centralised audio handler for playing simple sound effects.
+/// Holds references to pop sounds for pickups, successes and errors.
+/// </summary>
+public class AudioManager : MonoBehaviour
+{
+    public static AudioManager Instance { get; private set; }
+
+    [SerializeField] private AudioClip pickupClip;
+    [SerializeField] private AudioClip successClip;
+    [SerializeField] private AudioClip errorClip;
+
+    private AudioSource source;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        source = gameObject.AddComponent<AudioSource>();
+    }
+
+    public void PlayPickup() => PlayClip(pickupClip);
+    public void PlaySuccess() => PlayClip(successClip);
+    public void PlayError() => PlayClip(errorClip);
+
+    private void PlayClip(AudioClip clip)
+    {
+        if (clip != null && source != null)
+        {
+            source.PlayOneShot(clip);
+        }
+    }
+}

--- a/Assets/Scripts/Audio/AudioManager.cs.meta
+++ b/Assets/Scripts/Audio/AudioManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6f7cda7a0a84611b6eb09d4c02cbf0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Audio/FXManager.cs
+++ b/Assets/Scripts/Audio/FXManager.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple visual effects manager spawning particle systems for game events.
+/// </summary>
+public class FXManager : MonoBehaviour
+{
+    public static FXManager Instance { get; private set; }
+
+    [SerializeField] private ParticleSystem leavesPrefab;
+    [SerializeField] private ParticleSystem sparklePrefab;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void PlayLeaves(Vector3 position)
+    {
+        Spawn(leavesPrefab, position);
+    }
+
+    public void PlaySparkle(Vector3 position)
+    {
+        Spawn(sparklePrefab, position);
+    }
+
+    private void Spawn(ParticleSystem prefab, Vector3 position)
+    {
+        if (prefab == null)
+        {
+            return;
+        }
+
+        var ps = Instantiate(prefab, position, Quaternion.identity);
+        var main = ps.main;
+        Destroy(ps.gameObject, main.duration + main.startLifetime.constantMax);
+    }
+}

--- a/Assets/Scripts/Audio/FXManager.cs.meta
+++ b/Assets/Scripts/Audio/FXManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef458d8b22b54c368cfd1af5cf809527
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -25,6 +25,7 @@ public class Inventory : MonoBehaviour
     {
         woodCount += amount;
         OnWoodChanged?.Invoke(woodCount);
+        AudioManager.Instance?.PlayPickup();
     }
 
     public void RemoveWood(int amount)

--- a/Assets/Scripts/Minigame/MinigameManager.cs
+++ b/Assets/Scripts/Minigame/MinigameManager.cs
@@ -112,6 +112,15 @@ public class MinigameManager : MonoBehaviour
             gain = 2;
         }
 
+        if (gain > 1)
+        {
+            AudioManager.Instance?.PlaySuccess();
+        }
+        else
+        {
+            AudioManager.Instance?.PlayError();
+        }
+
         if (Inventory.Instance != null)
         {
             Inventory.Instance.AddWood(gain);

--- a/Assets/Scripts/Tree/Tree.cs
+++ b/Assets/Scripts/Tree/Tree.cs
@@ -37,6 +37,7 @@ public class Tree : Interactable
 
         int attemptNumber = (data != null ? data.attempts : 0) - remainingAttempts + 1;
         MinigameManager.StartGame(attemptNumber);
+        FXManager.Instance?.PlayLeaves(transform.position);
         remainingAttempts--;
 
         if (remainingAttempts <= 0)

--- a/Assets/Scripts/Village/Storage.cs
+++ b/Assets/Scripts/Village/Storage.cs
@@ -40,6 +40,7 @@ public class Storage : Interactable
         var quest = QuestManager.Instance.ActiveQuest;
         if (quest == null)
         {
+            AudioManager.Instance?.PlayError();
             return;
         }
 
@@ -47,6 +48,12 @@ public class Storage : Interactable
         {
             Inventory.Instance.RemoveWood(quest.woodRequired);
             villageProgress.AdvancePhase();
+            AudioManager.Instance?.PlaySuccess();
+            FXManager.Instance?.PlaySparkle(transform.position);
+        }
+        else
+        {
+            AudioManager.Instance?.PlayError();
         }
 
         if (deliverAllPanel != null)

--- a/Assets/Scripts/Village/VillageProgress.cs
+++ b/Assets/Scripts/Village/VillageProgress.cs
@@ -48,6 +48,7 @@ public class VillageProgress : MonoBehaviour
         }
 
         currentPhaseIndex++;
+        FXManager.Instance?.PlaySparkle(transform.position);
 
         if (IsComplete)
         {


### PR DESCRIPTION
## Summary
- Add global AudioManager for pickup, success and error pop sounds
- Introduce FXManager to spawn leaves and sparkle particles
- Hook up new SFX and VFX in inventory, minigame results, tree chopping, delivery and village progress

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_b_68acd29e54d8832e835fee3ea1129d3b