### PR TITLE
Persist wood count and quest progress

### DIFF
--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -19,6 +19,9 @@ public class Inventory : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
+
+        var data = SaveSystem.LoadGame();
+        woodCount = data.woodCount;
     }
 
     public void AddWood(int amount)
@@ -32,5 +35,10 @@ public class Inventory : MonoBehaviour
     {
         woodCount = Mathf.Max(0, woodCount - amount);
         OnWoodChanged?.Invoke(woodCount);
+    }
+
+    private void OnApplicationQuit()
+    {
+        SaveSystem.SaveGame();
     }
 }

--- a/Assets/Scripts/Quest/QuestBoard.cs
+++ b/Assets/Scripts/Quest/QuestBoard.cs
@@ -14,6 +14,8 @@ public class QuestBoard : Interactable
 
     private int currentIndex;
 
+    public int CurrentIndex => currentIndex;
+
     private void Start()
     {
         // Provide a default cycle of quests if none were assigned via the inspector.
@@ -23,6 +25,9 @@ public class QuestBoard : Interactable
             questQueue.Add(CreateQuest(15));
             questQueue.Add(CreateQuest(20));
         }
+
+        var data = SaveSystem.LoadGame();
+        currentIndex = Mathf.Clamp(data.questIndex, 0, Mathf.Max(questQueue.Count - 1, 0));
     }
 
     private QuestSO CreateQuest(int wood)

--- a/Assets/Scripts/SaveSystem.cs
+++ b/Assets/Scripts/SaveSystem.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+[Serializable]
+public class SaveData
+{
+    public int woodCount;
+    public int questIndex;
+    public int wellPhase;
+}
+
+public static class SaveSystem
+{
+    private static string SavePath => Path.Combine(Application.persistentDataPath, "save.json");
+
+    public static void SaveGame()
+    {
+        var data = new SaveData
+        {
+            woodCount = Inventory.Instance != null ? Inventory.Instance.woodCount : 0,
+            questIndex = UnityEngine.Object.FindObjectOfType<QuestBoard>()?.CurrentIndex ?? 0,
+            wellPhase = UnityEngine.Object.FindObjectOfType<VillageProgress>()?.CurrentPhaseIndex ?? 0
+        };
+
+        var json = JsonUtility.ToJson(data);
+        File.WriteAllText(SavePath, json);
+    }
+
+    public static SaveData LoadGame()
+    {
+        if (!File.Exists(SavePath))
+        {
+            return new SaveData();
+        }
+
+        var json = File.ReadAllText(SavePath);
+        return JsonUtility.FromJson<SaveData>(json);
+    }
+}

--- a/Assets/Scripts/Village/Storage.cs
+++ b/Assets/Scripts/Village/Storage.cs
@@ -50,6 +50,7 @@ public class Storage : Interactable
             villageProgress.AdvancePhase();
             AudioManager.Instance?.PlaySuccess();
             FXManager.Instance?.PlaySparkle(transform.position);
+            SaveSystem.SaveGame();
         }
         else
         {

--- a/Assets/Scripts/Village/VillageProgress.cs
+++ b/Assets/Scripts/Village/VillageProgress.cs
@@ -16,6 +16,14 @@ public class VillageProgress : MonoBehaviour
     private int currentPhaseIndex;
     private GameObject currentWell;
 
+    public int CurrentPhaseIndex => currentPhaseIndex;
+
+    private void Awake()
+    {
+        var data = SaveSystem.LoadGame();
+        currentPhaseIndex = data.wellPhase;
+    }
+
     private void Start()
     {
         SpawnPhase();


### PR DESCRIPTION
## Summary
- Save wood, quest, and well phase using Unity's JsonUtility
- Restore these values at startup
- Save automatically on deliveries and game exit

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures missing)*

------
https://chatgpt.com/codex/tasks/task_b_68acd39e240c832eae0284b86b0c9d5f